### PR TITLE
Fix install path for system installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(obs-gphoto ${LIBOBS_LIBRARIES} ${Gphoto2_LIBRARIES} ${Imag
 
 # install
 if(${SYSTEM_INSTALL})
-    install(TARGETS obs-gphoto DESTINATION /usr/lib/obs-plugins)
+    install(TARGETS obs-gphoto DESTINATION ${LIBOBS_PLUGIN_DESTINATION})
 else()
     install(DIRECTORY ${PLUGIN_DIRECTORY} DESTINATION $ENV{HOME}/.config/obs-studio/plugins USE_SOURCE_PERMISSIONS)
 endif()


### PR DESCRIPTION
System installs on debian previously installed to /usr/lib, instead of /usr/lib/x86_64-linux-gnu or similar

Tested on Linux Mint 19, not tested on any other systems.