### PR TITLE
Fix compatibility with imagemagick 7

### DIFF
--- a/src/gphoto-preview.c
+++ b/src/gphoto-preview.c
@@ -1,4 +1,4 @@
-#include <magick/MagickCore.h>
+#include <MagickCore/MagickCore.h>
 
 #include "gphoto-preview.h"
 #include "gphoto-utils.h"

--- a/src/gphoto-utils.c
+++ b/src/gphoto-utils.c
@@ -1,7 +1,7 @@
 #include <obs-module.h>
 #include <obs-internal.h>
 #include <gphoto2/gphoto2-camera.h>
-#include <magick/MagickCore.h>
+#include <MagickCore/MagickCore.h>
 
 #include "gphoto-preview.h"
 

--- a/src/timelapse.c
+++ b/src/timelapse.c
@@ -1,4 +1,4 @@
-#include <magick/MagickCore.h>
+#include <MagickCore/MagickCore.h>
 
 #include "timelapse.h"
 #include "gphoto-utils.h"


### PR DESCRIPTION
This might be up to discussion since it breaks compatilbility with imagemagick < 7, but I hadn't the time to come up with a cmake fix for this.

Properly, cmake should detect what version is available, and adapt the includes.